### PR TITLE
Add date and cache updates

### DIFF
--- a/phaser/phaser_sdcard_setup.sh
+++ b/phaser/phaser_sdcard_setup.sh
@@ -1,3 +1,7 @@
+# Update time and apt cache
+sudo date -s "$(wget --method=HEAD -qSO- --max-redirect=0 google.com 2>&1 | sed -n 's/^ *Date: *//p')"
+sudo apt update
+
 # Grab config.txt file. This applies the overlay, sets up the green heartbeat blinky light,
 # and enables the shutdown button
 


### PR DESCRIPTION
If the RPI and SD are new its likely the clock is off which makes it impossible to run the update scripts. This change will update the clock over HTTP and update the apt cache